### PR TITLE
Vielmetti 109 2018 w29

### DIFF
--- a/2018/2018-W29.md
+++ b/2018/2018-W29.md
@@ -2,32 +2,40 @@
 title: works on arm news 63 2018-w29
 number: 63
 date: 2018-07-20
-author: Ed Vielmetti, Packet
+writer: Ed Vielmetti, Packet
 editor: Zoe Allen, Packet
 ---
+
+Ed Vielmetti, the writer of the Works on Arm newsletter and the director of
+the Works on Arm cluster at Packet, will be at the Linaro Arm Hisilicon HPC
+workshop on Thursday, July 26, 2018 in Santa Clara, CA at Huawei. As a
+consequence, next week's newsletter will feature a trip report of from
+that conference, and will appear perhaps somewhat later than the usual time
+on Friday, July 27, 2018.
+
+The following week (2018-W31) is PTO for Ed who will be out of the office for
+the week. 
+
 ## Events
 
-* Linaro Connect, deadline for proposals is Monday July 23
+* Linaro Connect, deadline for proposals is Monday July 23.
 * Arm Linaro Hisilicon HPC workshop, Thursday July 27, Santa Clara CA
 * ARM RESEARCH SUMMIT 17-19 SEPTEMBER 2018 | ROBINSON COLLEGE, CAMBRIDGE, UK https://www.arm.com/company/events/research-summit
 
-## Link dump:
-
-* https://groups.google.com/forum/#!msg/golang-announce/RVR0FzIKBsU/PAxl4-ZVCAAJ Go 1.11 release
-* https://github.com/FabioLolix/Lolix-lists/blob/master/RunsOnARM.md
-* https://www.youtube.com/watch?v=v3cs67q5u-M - sahaj on icecream icecc
-
 ## HPC
 
+* OpenHPC using Open Build Service on Works on Arm cluster.
 * http://www.goingarm.com/ - Going Arm notes from ISC workshop
 * http://www.goingarm.com/slides/2018/ISC2018/ISC2018-GoingArmWS-Matsuoka-20180628.pdf - post-K architecture
 
+## Languages and libraries
 
-## Single board computers
+* https://groups.google.com/forum/#!msg/golang-announce/RVR0FzIKBsU/PAxl4-ZVCAAJ Go 1.11 release
+* https://www.youtube.com/watch?v=v3cs67q5u-M - sahaj on icecream icecc
 
-* https://twitter.com/thepine64/status/1020234773468499968 - RockPro64
-* https://twitter.com/armbian/status/1020271844027518976 - Armbian 
-* http://www.hexus.net/tech/items/network/120272-plex-qnap-armv8realtek-platforms-alpha-testing/ - Realtek
+## Operating Systems
+
+* https://github.com/FabioLolix/Lolix-lists/blob/master/RunsOnARM.md
 
 ## Cluster
 
@@ -41,3 +49,8 @@ editor: Zoe Allen, Packet
 
 * https://linux.die.net/man/1/make
 
+## Single board computers
+
+* https://twitter.com/thepine64/status/1020234773468499968 - RockPro64
+* https://twitter.com/armbian/status/1020271844027518976 - Armbian 
+* http://www.hexus.net/tech/items/network/120272-plex-qnap-armv8realtek-platforms-alpha-testing/ - Realtek

--- a/2018/2018-W29.md
+++ b/2018/2018-W29.md
@@ -10,23 +10,51 @@ Ed Vielmetti, the writer of the Works on Arm newsletter and the director of
 the Works on Arm cluster at Packet, will be at the Linaro Arm Hisilicon HPC
 workshop on Thursday, July 26, 2018 in Santa Clara, CA at Huawei. As a
 consequence, next week's newsletter will feature a trip report of from
-that conference, and will appear perhaps somewhat later than the usual time
+that workshop, and will appear perhaps somewhat later than the usual time
 on Friday, July 27, 2018.
 
 The following week (2018-W31) is PTO for Ed who will be out of the office for
-the week. 
+the week. The newsletter will be a repeat of 
+
+In this issue: Events include the Linaro Connect conference, Arm Architecture HPC Workshop, 
+Arm Research Summit. OpenHPC joins the Works on Arm cluster. Reports from the
+Going Arm workshop at ISC2018. Go 1.11rc2 released; "best Go ever". icecc ("ice cream")
+compiler for single-board clusters. Parallel makefiles with "make -j". 
+Inventory of arm64 operating systems. RockPro64 release, and Picocluster plans for RockPro64 cluster. Armbian.
 
 ## Events
 
-* Linaro Connect, deadline for proposals is Monday July 23.
-* Arm Linaro Hisilicon HPC workshop, Thursday July 27, Santa Clara CA
+Linaro Connect will be held 17-21 September 2018 in Vancouver, BC. 
+The deadline for proposals for talks is Monday July 23. 
+"The leading event for Open source software engineering on Arm".
+
+* http://connect.linaro.org/
+
+Arm Architecture HPC Workshop by Linaro and HiSilicon on 26th July 2018
+
+> How does the Arm-Powered supercomputing future look and how can you prepare for it? The Arm Architecture HPC Workshop will bring together the leading Arm vendors, end users and the open source development community in the Bay area, to discuss the latest products, developments and open source software support. 
+
+* https://www.linaro.org/latest/events/arm-hpc-santa-clara-2018/
+
 * ARM RESEARCH SUMMIT 17-19 SEPTEMBER 2018 | ROBINSON COLLEGE, CAMBRIDGE, UK https://www.arm.com/company/events/research-summit
 
 ## HPC
 
-* OpenHPC using Open Build Service on Works on Arm cluster.
+OpenHPC joins the Works on Arm cluster, using an OpenSUSE instance
+running on a Packet c1.large.arm Cavium ThunderX system to run
+the Open Build Service. We hope to have some kind of useful artifact
+to report on in time for the Arm Architecture HPC Workshop in Santa Clara.
+
+> OpenHPC is a collaborative, community effort that initiated from a desire to aggregate a number of common ingredients required to deploy and manage High Performance Computing (HPC) Linux clusters including provisioning tools, resource management, I/O clients, development tools, and a variety of scientific libraries. Packages provided by OpenHPC have been pre-built with HPC integration in mind with a goal to provide re-usable building blocks for the HPC community. 
+
+* http://openhpc.community/
+
 * http://www.goingarm.com/ - Going Arm notes from ISC workshop
 * http://www.goingarm.com/slides/2018/ISC2018/ISC2018-GoingArmWS-Matsuoka-20180628.pdf - post-K architecture
+
+## Cloud native 
+
+* https://github.com/pharmer/pharmer/releases/tag/0.1.0-rc.5 - Pharmer with support for Kubernetes 1.11
 
 ## Languages and libraries
 
@@ -37,14 +65,6 @@ the week.
 
 * https://github.com/FabioLolix/Lolix-lists/blob/master/RunsOnARM.md
 
-## Cluster
-
-* https://twitter.com/picocluster/status/1019711815343722498
-
-## Cloud native 
-
-* https://github.com/pharmer/pharmer/releases/tag/0.1.0-rc.5 - Pharmer with support for Kubernetes 1.11
-
 ## Command of the week is "make -j"
 
 * https://linux.die.net/man/1/make
@@ -52,5 +72,5 @@ the week.
 ## Single board computers
 
 * https://twitter.com/thepine64/status/1020234773468499968 - RockPro64
+* https://twitter.com/picocluster/status/1019711815343722498 Picocluster plans for RockPro64 cluster.
 * https://twitter.com/armbian/status/1020271844027518976 - Armbian 
-* http://www.hexus.net/tech/items/network/120272-plex-qnap-armv8realtek-platforms-alpha-testing/ - Realtek

--- a/2018/2018-W29.md
+++ b/2018/2018-W29.md
@@ -14,7 +14,8 @@ that workshop, and will appear perhaps somewhat later than the usual time
 on Friday, July 27, 2018.
 
 The following week (2018-W31) is PTO for Ed who will be out of the office for
-the week. The newsletter will be a repeat of 
+the week. The newsletter will be a reference guide for commonly asked questions
+about the newsletter, the project, and the cluster. 
 
 In this issue: Events include the Linaro Connect conference, Arm Architecture HPC Workshop, 
 Arm Research Summit. OpenHPC joins the Works on Arm cluster. Reports from the
@@ -30,35 +31,53 @@ The deadline for proposals for talks is Monday July 23.
 
 * http://connect.linaro.org/
 
-Arm Architecture HPC Workshop by Linaro and HiSilicon on 26th July 2018
+Arm Architecture HPC Workshop by Linaro and HiSilicon on 26th July 2018.
 
 > How does the Arm-Powered supercomputing future look and how can you prepare for it? The Arm Architecture HPC Workshop will bring together the leading Arm vendors, end users and the open source development community in the Bay area, to discuss the latest products, developments and open source software support. 
 
+Ed Vielmetti from Packet and Works on Arm will be attending the event; say hi to me there!
+
 * https://www.linaro.org/latest/events/arm-hpc-santa-clara-2018/
 
-* ARM RESEARCH SUMMIT 17-19 SEPTEMBER 2018 | ROBINSON COLLEGE, CAMBRIDGE, UK https://www.arm.com/company/events/research-summit
+The Arm Research Summit is September 17-19, 2018 at Robinson College, Cambridge UK.
+
+> In a multi-track three-day program, hear from expert researchers discussing the latest developments, future trends and disruptive technologies affecting our industry, and the world surrounding it.
+
+Please let us know if you will be at this event!
+
+* https://www.arm.com/company/events/research-summit
 
 ## HPC
 
 OpenHPC joins the Works on Arm cluster, using an OpenSUSE instance
 running on a Packet c1.large.arm Cavium ThunderX system to run
-the Open Build Service. We hope to have some kind of useful artifact
-to report on in time for the Arm Architecture HPC Workshop in Santa Clara.
+the Open Build Service. 
 
 > OpenHPC is a collaborative, community effort that initiated from a desire to aggregate a number of common ingredients required to deploy and manage High Performance Computing (HPC) Linux clusters including provisioning tools, resource management, I/O clients, development tools, and a variety of scientific libraries. Packages provided by OpenHPC have been pre-built with HPC integration in mind with a goal to provide re-usable building blocks for the HPC community. 
 
+We hope to have some kind of useful artifact
+to report on in time for the Arm Architecture HPC Workshop in Santa Clara.
+
 * http://openhpc.community/
 
-* http://www.goingarm.com/ - Going Arm notes from ISC workshop
+Going Arm was a workshop at ISC18. Notes and slides from the talks presented on HPC
+topics are now all online.
+
+* http://www.goingarm.com/ 
 * http://www.goingarm.com/slides/2018/ISC2018/ISC2018-GoingArmWS-Matsuoka-20180628.pdf - post-K architecture
 
 ## Cloud native 
 
-* https://github.com/pharmer/pharmer/releases/tag/0.1.0-rc.5 - Pharmer with support for Kubernetes 1.11
+A beta release of Pharmer with support for Kubernetes 1.11 has been
+released. This system does bare-metal high availability provisioning
+of Kubernetes clusters to a variety of cloud and bare metal systems
+including Packet.
+
+* https://github.com/pharmer/pharmer/releases/tag/0.1.0-rc.5 
 
 ## Languages and libraries
 
-* https://groups.google.com/forum/#!msg/golang-announce/RVR0FzIKBsU/PAxl4-ZVCAAJ Go 1.11 release
+* https://groups.google.com/forum/#!msg/golang-announce/RVR0FzIKBsU/PAxl4-ZVCAAJ Go 1.11rc2 release
 * https://www.youtube.com/watch?v=v3cs67q5u-M - sahaj on icecream icecc
 
 ## Operating Systems

--- a/2018/2018-W29.md
+++ b/2018/2018-W29.md
@@ -17,21 +17,24 @@ The following week (2018-W31) is PTO for Ed who will be out of the office for
 the week. The newsletter will be a reference guide for commonly asked questions
 about the newsletter, the project, and the cluster. 
 
-In this issue: Events include the Linaro Connect conference, Arm Architecture HPC Workshop, 
+## In this issue
+
+Events include the Linaro Connect conference, Arm Architecture HPC Workshop, 
 Arm Research Summit. OpenHPC joins the Works on Arm cluster. Reports from the
 Going Arm workshop at ISC2018. Go 1.11rc2 released; "best Go ever". icecc ("ice cream")
 compiler for single-board clusters. Parallel makefiles with "make -j". 
-Inventory of arm64 operating systems. RockPro64 release, and Picocluster plans for RockPro64 cluster. Armbian.
+Inventory of arm64 operating systems. RockPro64 release, and Picocluster 
+plans for RockPro64 cluster. Armbian.
 
 ## Events
 
-Linaro Connect will be held 17-21 September 2018 in Vancouver, BC. 
+**Linaro Connect** will be held 17-21 September 2018 in Vancouver, BC. 
 The deadline for proposals for talks is Monday July 23. 
 "The leading event for Open source software engineering on Arm".
 
 * http://connect.linaro.org/
 
-Arm Architecture HPC Workshop by Linaro and HiSilicon on 26th July 2018.
+**Arm Architecture HPC Workshop** by Linaro and HiSilicon on 26th July 2018.
 
 > How does the Arm-Powered supercomputing future look and how can you prepare for it? The Arm Architecture HPC Workshop will bring together the leading Arm vendors, end users and the open source development community in the Bay area, to discuss the latest products, developments and open source software support. 
 
@@ -39,7 +42,7 @@ Ed Vielmetti from Packet and Works on Arm will be attending the event; say hi to
 
 * https://www.linaro.org/latest/events/arm-hpc-santa-clara-2018/
 
-The Arm Research Summit is September 17-19, 2018 at Robinson College, Cambridge UK.
+The **Arm Research Summit** is September 17-19, 2018 at Robinson College, Cambridge UK.
 
 > In a multi-track three-day program, hear from expert researchers discussing the latest developments, future trends and disruptive technologies affecting our industry, and the world surrounding it.
 
@@ -49,18 +52,19 @@ Please let us know if you will be at this event!
 
 ## HPC
 
-OpenHPC joins the Works on Arm cluster, using an OpenSUSE instance
+**OpenHPC** joins the Works on Arm cluster, using an OpenSUSE instance
 running on a Packet c1.large.arm Cavium ThunderX system to run
 the Open Build Service. 
 
 > OpenHPC is a collaborative, community effort that initiated from a desire to aggregate a number of common ingredients required to deploy and manage High Performance Computing (HPC) Linux clusters including provisioning tools, resource management, I/O clients, development tools, and a variety of scientific libraries. Packages provided by OpenHPC have been pre-built with HPC integration in mind with a goal to provide re-usable building blocks for the HPC community. 
 
-We hope to have some kind of useful artifact
-to report on in time for the Arm Architecture HPC Workshop in Santa Clara.
+We hope to have a report on 
+this effort
+in time to share for the Arm Architecture HPC Workshop in Santa Clara.
 
 * http://openhpc.community/
 
-Going Arm was a workshop at ISC18. Notes and slides from the talks presented on HPC
+**Going Arm** was a workshop at ISC18. Notes and slides from the talks presented on HPC
 topics are now all online.
 
 * http://www.goingarm.com/ 
@@ -68,7 +72,7 @@ topics are now all online.
 
 ## Cloud native 
 
-A beta release of Pharmer with support for Kubernetes 1.11 has been
+A beta release of **Pharmer** with support for **Kubernetes 1.11** has been
 released. This system does bare-metal high availability provisioning
 of Kubernetes clusters to a variety of cloud and bare metal systems
 including Packet.
@@ -77,10 +81,26 @@ including Packet.
 
 ## Languages and libraries
 
-* https://groups.google.com/forum/#!msg/golang-announce/RVR0FzIKBsU/PAxl4-ZVCAAJ Go 1.11rc2 release
-* https://www.youtube.com/watch?v=v3cs67q5u-M - sahaj on icecream icecc
+**Go 1.11rc2** has been released, "the best Go ever". This release
+includes several additional optimizations for arm64. If you have
+the means to test your Go-based project to build for RC2, this
+is an opportune time to do so to check for performance.
+
+* https://groups.google.com/forum/#!msg/golang-announce/RVR0FzIKBsU/PAxl4-ZVCAAJ 
+
+**icecc** ("Ice Cream") is a parallel computing environment
+for clusters of machines including single-board computers
+running C and C++ compiles. In this video, Sahaj from Linaro
+demonstates the use of icecc to speed up compiles by distributing
+the opearations over a 12 machine, 96 core cluster.
+
+* https://www.youtube.com/watch?v=v3cs67q5u-M 
 
 ## Operating Systems
+
+**RunsOnARM** is a list maintained by Github user @FabioLolix
+to collect information about operating systems that run on 64-bit
+arm64 single-board computers.
 
 * https://github.com/FabioLolix/Lolix-lists/blob/master/RunsOnARM.md
 

--- a/2018/2018-W29.md
+++ b/2018/2018-W29.md
@@ -96,10 +96,14 @@ is an opportune time to do so to check for performance.
 
 **icecc** ("Ice Cream") is a parallel computing environment
 for clusters of machines including single-board computers
-running C and C++ compiles. In this video, Sahaj from Linaro
-demonstates the use of icecc to speed up compiles by distributing
-the opearations over a 12 machine, 96 core cluster.
+running C and C++ compiles. In this video, Sahaj Sarup,
+an application engineer from Linaro and a regular contributor
+to the Works on Arm weekly Wednesday call,
+demonstates the use of `icecream` to speed up compiles by distributing
+the workload over a cluster of single-board computers
+from `96Boards`.
 
+* https://github.com/icecc/icecream
 * https://www.youtube.com/watch?v=v3cs67q5u-M 
 
 ## Operating Systems
@@ -125,6 +129,21 @@ run an unlimited number of jobs.
 
 ## Single board computers
 
-* https://twitter.com/thepine64/status/1020234773468499968 - RockPro64
-* https://twitter.com/picocluster/status/1019711815343722498 Picocluster plans for RockPro64 cluster.
-* https://twitter.com/armbian/status/1020271844027518976 - Armbian 
+The **RockPro64** is now shipping. The v2.1 revision schematics 
+for the system are available, showing the **Rockchip RK3399 SoC** at the heart
+of this design. **Picocluster** has indicated that they have
+plans for a mechanical design for a case and power supply and
+cabling to build a RockPro64 cluster.
+
+* https://twitter.com/thepine64/status/1020234773468499968 
+* http://files.pine64.org/doc/rockpro64/rockpro64_v21-SCH.pdf
+* https://twitter.com/picocluster/status/1019711815343722498 
+
+**Armbian** has a preview and photo of a pre-release
+version of the **NanoPi NEO4**, the smallest known Rockchip RK3399 powered board. 
+
+* https://twitter.com/armbian/status/1020271844027518976 
+* https://forum.armbian.com/topic/7750-nanopi-neo4/
+* https://twitter.com/iloverockchip
+* http://www.rock-chips.com/
+* http://nanopi.org/

--- a/2018/2018-W29.md
+++ b/2018/2018-W29.md
@@ -27,7 +27,7 @@ about the newsletter, the project, and the cluster.
 
 Issue 63: Events include the Linaro Connect conference, Arm Architecture HPC Workshop, 
 and Arm Research Summit. OpenHPC joins the Works on Arm cluster. Reports from the
-Going Arm workshop at ISC2018. Go 1.11rc2 released; "best Go ever". icecc ("ice cream")
+Going Arm workshop at ISC2018. Go 1.11beta2 released; "best Go ever". icecc ("ice cream")
 compiler for single-board clusters. Parallel makefiles with "make -j". 
 Inventory of arm64 operating systems. RockPro64 release, and Picocluster 
 plans for RockPro64 cluster. Armbian.
@@ -87,9 +87,9 @@ including Packet.
 
 ## Languages and libraries
 
-**Go 1.11rc2** has been released, "the best Go ever". This release
+**Go 1.11beta2** has been released, "the best Go ever". This release
 includes several additional optimizations for arm64. If you have
-the means to test your Go-based project to build for RC2, this
+the means to test your Go-based project to build for beta2, this
 is an opportune time to do so to check for performance.
 
 * https://groups.google.com/forum/#!msg/golang-announce/RVR0FzIKBsU/PAxl4-ZVCAAJ 

--- a/2018/2018-W29.md
+++ b/2018/2018-W29.md
@@ -6,21 +6,27 @@ writer: Ed Vielmetti, Packet
 editor: Zoe Allen, Packet
 ---
 
-Ed Vielmetti, the writer of the Works on Arm newsletter and the director of
-the Works on Arm cluster at Packet, will be at the Linaro Arm Hisilicon HPC
-workshop on Thursday, July 26, 2018 in Santa Clara, CA at Huawei. As a
-consequence, next week's newsletter will feature a trip report of from
+Welcome to **Works on Arm News** for Friday, July 20, 2018. This
+newsletter is distributed via the @worksonarm Twitter account on
+Fridays, archived at http://worksonarm.com/blog , and distributed
+by electronic mail on Mondays. **Ed Vielmetti** from Packet directs the project
+and writes the newsletter, and **Zoe Allen** from Packet is editor.
+
+Ed will be at the **Arm Architecture HPC Workshop**
+workshop on Thursday, July 26, 2018 in Santa Clara, CA at **Huawei** and organized
+by **Linaro**. As a
+consequence, next week's Issue 64 newsletter will feature a trip report of from
 that workshop, and will appear perhaps somewhat later than the usual time
 on Friday, July 27, 2018.
 
 The following week (2018-W31) is PTO for Ed who will be out of the office for
-the week. The newsletter will be a reference guide for commonly asked questions
+the week. The Issue 65 newsletter will be a reference guide for commonly asked questions
 about the newsletter, the project, and the cluster. 
 
 ## In this issue
 
-Events include the Linaro Connect conference, Arm Architecture HPC Workshop, 
-Arm Research Summit. OpenHPC joins the Works on Arm cluster. Reports from the
+Issue 63: Events include the Linaro Connect conference, Arm Architecture HPC Workshop, 
+and Arm Research Summit. OpenHPC joins the Works on Arm cluster. Reports from the
 Going Arm workshop at ISC2018. Go 1.11rc2 released; "best Go ever". icecc ("ice cream")
 compiler for single-board clusters. Parallel makefiles with "make -j". 
 Inventory of arm64 operating systems. RockPro64 release, and Picocluster 
@@ -52,9 +58,9 @@ Please let us know if you will be at this event!
 
 ## HPC
 
-**OpenHPC** joins the Works on Arm cluster, using an OpenSUSE instance
-running on a Packet c1.large.arm Cavium ThunderX system to run
-the Open Build Service. 
+**OpenHPC** joins the Works on Arm cluster, using an **OpenSUSE** instance
+running on a **Packet c1.large.arm Cavium ThunderX** system to run
+the **Open Build Service**. 
 
 > OpenHPC is a collaborative, community effort that initiated from a desire to aggregate a number of common ingredients required to deploy and manage High Performance Computing (HPC) Linux clusters including provisioning tools, resource management, I/O clients, development tools, and a variety of scientific libraries. Packages provided by OpenHPC have been pre-built with HPC integration in mind with a goal to provide re-usable building blocks for the HPC community. 
 
@@ -64,7 +70,7 @@ in time to share for the Arm Architecture HPC Workshop in Santa Clara.
 
 * http://openhpc.community/
 
-**Going Arm** was a workshop at ISC18. Notes and slides from the talks presented on HPC
+**Going Arm** was a workshop at **ISC18**. Notes and slides from the talks presented on HPC
 topics are now all online.
 
 * http://www.goingarm.com/ 
@@ -106,7 +112,16 @@ arm64 single-board computers.
 
 ## Command of the week is "make -j"
 
+The `make -j` option is a necessary feature for fast compiles
+if you are building software on a manycore system like the
+Packet **c1.large.arm** systems found in the Works on Arm cluster.
+Use it to configure the number of jobs running at once, or to 
+run an unlimited number of jobs. 
+
+> If the ‘-j’ option is followed by an integer, this is the number of recipes to execute at once; this is called the number of job slots. If there is nothing looking like an integer after the ‘-j’ option, there is no limit on the number of job slots. The default number of job slots is one, which means serial execution (one thing at a time).
+
 * https://linux.die.net/man/1/make
+* https://www.gnu.org/software/make/manual/html_node/Parallel.html
 
 ## Single board computers
 

--- a/2018/2018-W29.md
+++ b/2018/2018-W29.md
@@ -1,0 +1,43 @@
+---
+title: works on arm news 63 2018-w29
+number: 63
+date: 2018-07-20
+author: Ed Vielmetti, Packet
+editor: Zoe Allen, Packet
+---
+## Events
+
+* Linaro Connect, deadline for proposals is Monday July 23
+* Arm Linaro Hisilicon HPC workshop, Thursday July 27, Santa Clara CA
+* ARM RESEARCH SUMMIT 17-19 SEPTEMBER 2018 | ROBINSON COLLEGE, CAMBRIDGE, UK https://www.arm.com/company/events/research-summit
+
+## Link dump:
+
+* https://groups.google.com/forum/#!msg/golang-announce/RVR0FzIKBsU/PAxl4-ZVCAAJ Go 1.11 release
+* https://github.com/FabioLolix/Lolix-lists/blob/master/RunsOnARM.md
+* https://www.youtube.com/watch?v=v3cs67q5u-M - sahaj on icecream icecc
+
+## HPC
+
+* http://www.goingarm.com/ - Going Arm notes from ISC workshop
+* http://www.goingarm.com/slides/2018/ISC2018/ISC2018-GoingArmWS-Matsuoka-20180628.pdf - post-K architecture
+
+
+## Single board computers
+
+* https://twitter.com/thepine64/status/1020234773468499968 - RockPro64
+* https://twitter.com/armbian/status/1020271844027518976 - Armbian 
+* http://www.hexus.net/tech/items/network/120272-plex-qnap-armv8realtek-platforms-alpha-testing/ - Realtek
+
+## Cluster
+
+* https://twitter.com/picocluster/status/1019711815343722498
+
+## Cloud native 
+
+* https://github.com/pharmer/pharmer/releases/tag/0.1.0-rc.5 - Pharmer with support for Kubernetes 1.11
+
+## Command of the week is "make -j"
+
+* https://linux.die.net/man/1/make
+


### PR DESCRIPTION
Issue 63: Events include the Linaro Connect conference, Arm Architecture HPC Workshop, and Arm Research Summit. OpenHPC joins the Works on Arm cluster. Reports from the Going Arm workshop at ISC2018. Go 1.11rc2 released; "best Go ever". icecc ("ice cream") compiler for single-board clusters. Parallel makefiles with "make -j". Inventory of arm64 operating systems. RockPro64 release, and Picocluster plans for RockPro64 cluster. Armbian preview of the NEO4.

